### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,18 +11,19 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-    - name: Install SSH Client
-      uses: webfactory/ssh-agent@v0.4.1
-      with:
-        ssh-private-key: ${{ secrets.DEPLOY_KEY }}
     - name: Install Julia
       uses: julia-actions/setup-julia@v1
       with:
-        version: 1.3.0
-    - run: julia -e 'using Pkg; Pkg.add("Franklin"); using Franklin; optimize()'
+        version: 1.5
+    - run: julia -e '
+            using Pkg; Pkg.add(["NodeJS", "Franklin"]);
+            using NodeJS; run(`$(npm_cmd()) install highlight.js`);
+            using Franklin;
+            Pkg.activate("."); Pkg.instantiate();
+            optimize(minify=false)'
     - name: Build and Deploy
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
-        SSH: true
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
         FOLDER: __site


### PR DESCRIPTION
This is a follow up to #11 which should be better.

In short the old setup required an SSH path, but then GitHub action changed something and that setup was broken. Anyway this one is simpler, doesn't require keys to be set, only uses the Github Token.

cc @ViralBShah 